### PR TITLE
fix tox requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,4 @@ commands =
     nosetests
 deps =
     nose>=1.3.0
+    six>=1.3.0


### PR DESCRIPTION
Added `six` requirement to avoid:

```
======================================================================
ERROR: Failure: ImportError (No module named six)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fermayo/Documents/tutum/pycharm/bgtunnel/.tox/py27/lib/python2.7/site-packages/nose/loader.py", line 413, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/fermayo/Documents/tutum/pycharm/bgtunnel/.tox/py27/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/fermayo/Documents/tutum/pycharm/bgtunnel/.tox/py27/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/fermayo/Documents/tutum/pycharm/bgtunnel/tests/__init__.py", line 1, in <module>
    from .base import *
  File "/Users/fermayo/Documents/tutum/pycharm/bgtunnel/tests/base.py", line 5, in <module>
    import six
ImportError: No module named six
```
