### PR TITLE
Open hangs without "Welcome" message

### DIFF
--- a/bgtunnel.py
+++ b/bgtunnel.py
@@ -214,12 +214,13 @@ class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):
                  bind_address='127.0.0.1', bind_port=None,
                  host_address='127.0.0.1', host_port=None,
                  silent=False, ssh_path=None, dont_sudo=False,
-                 identity_file=None):
+                 identity_file=None, expect_hello=True):
         self.should_exit = False
         self.dont_sudo = dont_sudo
         self.stdout = None
         self.stderr = None
         self.ssh_path = ssh_path or get_ssh_path()
+        self.expect_hello = expect_hello
 
         self.ssh_is_ready = False
 
@@ -323,6 +324,9 @@ class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):
     def _validate_ssh_process(self, proc):
         stdout_queue = self.get_output_queue(proc.stdout)
         stderr_queue = self.get_output_queue(proc.stderr)
+        if not self.expect_hello:
+          return True
+
         while True:
             try:
                 stderr_line = stderr_queue.get_nowait()


### PR DESCRIPTION
I'm seeing an infinite hang in `_validate_ssh_process`. Here's what I think is supposed to happen: There are two threads, one each for reading from stdout and stderr. Upon stdout receiving a message to stdout, the validation succeeds and the program can continue. 

This seems to expect some kind of a "welcome" message from the service. If there is none, then validation loops forever. This is potentially worse than a validation failure, as it hangs the parent program.  

Here's a small patch to allow skipping this validation entirely - it should probably have a command line option added if others find this useful. I'm currently using this to connect to webserver that's only exposed to 127.0.0.1 on a remote machine. 
