### PR TITLE
Ignore ssh warning 'adding host to list of know hosts'

### DIFF
--- a/bgtunnel.py
+++ b/bgtunnel.py
@@ -334,7 +334,7 @@ class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):
             except Empty:
                 pass
             else:
-                if stderr_line.strip():
+                if stderr_line.strip() and not "Warning: Permanently added" in stderr_line:
                     return stderr_line
             try:
                 stdout_line = stdout_queue.get_nowait()


### PR DESCRIPTION
Hi,

Connecting to an unknown host does not work, as ssh prints a warning on stderr. The patch allows bgtunnel to establish a tunnel to new host.

Best,
Alex
