### PR TITLE
Identity file being generated by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 *.sublime-workspace
 .env
 __pycache__
+/build/

--- a/bgtunnel.py
+++ b/bgtunnel.py
@@ -247,7 +247,9 @@ class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):
         validate_ssh_cmd_exists(self.ssh_path)
 
         # The path to the private key file to use
-        self.identity_file = normalize_path(identity_file or '') or None
+        self.identity_file = None
+        if identity_file is not None:
+            self.identity_file = normalize_path(identity_file or '') or None
 
         super(SSHTunnelForwarderThread, self).__init__()
 


### PR DESCRIPTION
I am getting a spurious -i being generated. seems that expand user ret
on  fedora core python-2.7.5-15.fc20.x86_64

>>> os.path.abspath(os.path.expanduser(""))
'/home/mdupont/experiments/bgtunnel'