### PR TITLE
Usedefaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 *.sublime-workspace
 .env
 __pycache__
+/build/

--- a/bgtunnel.py
+++ b/bgtunnel.py
@@ -170,9 +170,12 @@ class SSHString(UnicodeMagicMixin):
                 raise self.exception_class(u'{} cannot be empty'.format(key))
 
     def __unicode__(self):
-        return u'{}@{}'.format(self.user, self.address)
+        if self.user != SSHString.user_default:
+            return u'{}@{}'.format(self.user, self.address)
+        else:
+            return u'{}'.format(self.address)
 
-    def __repr__(self):
+    def __repr__(self):        
         return u'<{}: {}>'.format(self.__class__.__name__, self)
 
     def parse(self, s):
@@ -191,7 +194,10 @@ class AddressPortString(SSHString):
     exception_class = AddressPortStringValueError
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.address, self.port)
+        if self.address != AddressPortString.addr_default :
+            return u'{}:{}'.format(self.address, self.port)
+        else:
+            return u'{}'.format(self.port)
 
 
 class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):

--- a/bgtunnel.py
+++ b/bgtunnel.py
@@ -247,7 +247,9 @@ class SSHTunnelForwarderThread(threading.Thread, UnicodeMagicMixin):
         validate_ssh_cmd_exists(self.ssh_path)
 
         # The path to the private key file to use
-        self.identity_file = normalize_path(identity_file or '') or None
+        self.identity_file = None
+        if identity_file is not None:
+            self.identity_file = normalize_path(identity_file or '') or None
 
         super(SSHTunnelForwarderThread, self).__init__()
 


### PR DESCRIPTION
Here is a simple hack to allow ssh to use defaults. We don't need to specify the user and host if not needed. 